### PR TITLE
web socket issue workaround in case of safari browser, disconnect issue.

### DIFF
--- a/hooks/collaborative-ddl-spreadsheet-hook/docroot/custom_jsps/html/portlet/dynamic_data_lists/js/rivet-collaboration-spreadsheet.js
+++ b/hooks/collaborative-ddl-spreadsheet-hook/docroot/custom_jsps/html/portlet/dynamic_data_lists/js/rivet-collaboration-spreadsheet.js
@@ -129,6 +129,9 @@ AUI.add(
                         atmosphere.util.on(window, "beforeunload", function (event) {
                             atmosphere.unsubscribe();
                         });
+ 			atmosphere.util.on(window, "unload", function (event) {
+                            atmosphere.unsubscribe();
+                        });
 
                         instance.ws = atmosphere.subscribe(request);
                     },


### PR DESCRIPTION
Added the unload event listener and calling atmosphere.unsubscribe functionality manually.
